### PR TITLE
imp: recebe username como input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ flake8:
 	python3 -m flake8 --append-config=setup.cfg
 
 test:
-	GITHUB_ACTOR=tryber GITHUB_REPOSITORY=betrybe/pytest-evaluator-action python3 -m pytest -s
+	INPUT_PR_AUTHOR_USERNAME=tryber GITHUB_REPOSITORY=betrybe/pytest-evaluator-action python3 -m pytest -s
 
 build:
 	docker build . -t 'pytest_evaluator_action'

--- a/README.md
+++ b/README.md
@@ -51,19 +51,25 @@ jobs:
         with:
           evaluation-data: ${{ steps.pytest_evaluator.outputs.result }}
           environment: staging
-          pr-number: ${{ github.event.number }}
+          pr-number: ${{ github.event.inputs.pr_number }}
 
 ```
 
 ## Inputs
 
-### `repository_main_branch`
+- `repository_main_branch`
 
-**Required**
+  **Required**
 
-**Default: "master"**
+  **Default: "master"**
 
-GitHub main branch to get the original tests and requirements.
+  GitHub main branch to get the original tests and requirements.
+
+- `pr_author_username`
+
+  **Required**
+
+  Pull Request author username.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,20 @@ To call the evaluator action you must create `.github/workflows/main.yml` in the
 
 ```yml
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      dispatch_token:
+        description: 'Token that authorize the dispatch'
+        required: true
+      head_sha:
+        description: 'Head commit SHA that dispatched the workflow'
+        required: true
+      pr_author_username:
+        description: 'Pull Request author username'
+        required: true
+      pr_number:
+        description: 'Pull Request number that dispatched the workflow'
+        required: true
 
 jobs:
   evaluator_job:
@@ -44,7 +56,7 @@ jobs:
       - name: Pytest Evaluator Step
         uses: betrybe/pytest-evaluator-action@v*
         with:
-          repository_main_branch: master
+          pr_author_username: ${{ github.event.inputs.pr_author_username }}
         id: pytest_evaluator
       - name: Store evaluation step
         uses: betrybe/store-evaluation-action@v2
@@ -57,14 +69,6 @@ jobs:
 
 ## Inputs
 
-- `repository_main_branch`
-
-  **Required**
-
-  **Default: "master"**
-
-  GitHub main branch to get the original tests and requirements.
-
 - `pr_author_username`
 
   **Required**
@@ -73,9 +77,9 @@ jobs:
 
 ### Outputs
 
-#### `result`
+- `result`
 
-Evaluation result JSON in base64 format.
+  Evaluation result JSON in base64 format.
 
 ## Trybe requirements and expected results
 

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,8 @@
 name: 'Pytest Evaluator'
 description: 'Run Pytest on project and return the results formatted'
 inputs:
-  repository_main_branch:
-    description: 'GitHub main branch to get the original tests and requirements.'
-    default: 'master'
-    required: true
   pr_author_username:
-    description: 'Pull Request author username'
+    description: 'Pull Request author username.'
     required: true
 outputs:
   result:

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: 'GitHub main branch to get the original tests and requirements.'
     default: 'master'
     required: true
+  pr_author_username:
+    description: 'Pull Request author username'
+    required: true
 outputs:
   result:
     description: 'Evaluation JSON results in base64 format.'

--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -41,7 +41,7 @@ def generate_result(report_file, req_file):
         evaluations.append(evaluation)
 
     return {
-        'github_username': os.getenv('GITHUB_ACTOR', ''),
+        'github_username': os.getenv('INPUT_PR_AUTHOR_USERNAME', ''),
         'github_repository_name': os.getenv('GITHUB_REPOSITORY', ''),
         'evaluations': evaluations
     }


### PR DESCRIPTION
Devido as alterações na [LEARN-869](https://trybe.atlassian.net/browse/LEARN-869?atlOrigin=eyJpIjoiNjk5MjBkZDIzNTM2NDY5NmExMGJjYmRjN2NlZDAzYjAiLCJwIjoiaiJ9) e como o _workflow_ é disparado via **Github App Selfhosted**, a envvar `GITHUB_ACTOR` não poderá ser usada para pegar o **username** da pessoa estudante. Além disso, o **número** da Pull Request não vem no contexto do evento da _action_. Foi modificado para estes dados serem enviados pelo Github App via _input_. Assim sendo, será necessário modificar os avaliadores para o novo formato.