### PR TITLE
Aceitar xfailed como sucesso

### DIFF
--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -4,6 +4,7 @@ import sys
 
 FAILED_GRADE = 1
 PASSED_GRADE = 3
+ACCEPTABLE_OUTCOMES = {'passed', 'xfailed'}
 
 
 def generate_result(report_file, req_file):
@@ -36,7 +37,7 @@ def generate_result(report_file, req_file):
             continue
 
         test_result = next(iter(test_result))
-        if test_result['outcome'] == 'passed':
+        if test_result['outcome'] in ACCEPTABLE_OUTCOMES:
             evaluation['grade'] = PASSED_GRADE
         evaluations.append(evaluation)
 

--- a/tests/fixture/report.json
+++ b/tests/fixture/report.json
@@ -47,10 +47,34 @@
                     "outcome": "passed"
                 },
                 "outcome": "failed"
+            },
+            {
+                "name": "tests/sorting/test_sorting.py::test_sort_by[sort_by_strings]",
+                "duration": 0.0008007920000000501,
+                "run_index": 24,
+                "setup": {
+                    "name": "setup",
+                    "duration": 0.00023737499999998413,
+                    "outcome": "passed"
+                },
+                "call": {
+                    "name": "call",
+                    "duration": 0.0002031250000000817,
+                    "outcome": "xfailed",
+                    "xfail_reason": "",
+                    "longrepr": "jobs_by_max_salary = [{'max_salary': '1230'}, {'max_salary': '3230'}, {'max_salary': ''}, {'max_salary': '2230'}, {}]\njobs_by_min_salary = [{'min_salary': '1230'}, {'min_salary': '3230'}, {'min_salary': ''}, {'min_salary': '2230'}, {}]\njobs_by_date_posted = [{'date_posted': '2020-12-01'}, {'date_posted': '2020-12-31'}, {'date_posted': ''}, {'date_posted': '2020-12-20'}, {}]\n\n    def test_sort_by(jobs_by_max_salary, jobs_by_min_salary, jobs_by_date_posted):\n        sort_by(jobs_by_max_salary, 'max_salary')\n>       assert jobs_by_max_salary[0]['max_salary'] == '3230'\nE       AssertionError: assert '1230' == '3230'\nE         - 3230\nE         ? ^\nE         + 1230\nE         ? ^\n\ntests/sorting/test_sorting.py:40: AssertionError"
+                },
+                "teardown": {
+                    "name": "teardown",
+                    "duration": 0.00012291700000000017,
+                    "outcome": "passed"
+                },
+                "outcome": "xfailed"
             }
         ],
         "summary": {
             "passed": 1,
+            "xfailed": 1,
             "num_tests": 1,
             "duration": 0.09271740913391113
         },

--- a/tests/fixture/requirements.json
+++ b/tests/fixture/requirements.json
@@ -16,7 +16,7 @@
       "bonus": false
     },
     {
-      "identifier": "tests/sorting/test_sorting.py::test_sort_by[sort_by_strings]",
+      "identifier": "test_sort_by[sort_by_strings]",
       "description": "Confere que o teste não aprova a implementação sort_by_strings",
       "bonus": false
     }

--- a/tests/fixture/requirements.json
+++ b/tests/fixture/requirements.json
@@ -14,6 +14,11 @@
       "identifier": "test_csv_importer_arquivo_nao_encontrado",
       "description": "Caso o arquivo não exista, deve ser exibida a mensagem \"Arquivo {path/to/file.json} não encontrado\"",
       "bonus": false
+    },
+    {
+      "identifier": "tests/sorting/test_sorting.py::test_sort_by[sort_by_strings]",
+      "description": "Confere que o teste não aprova a implementação sort_by_strings",
+      "bonus": false
     }
   ]
 }

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -27,6 +27,9 @@ def test_generate_result_success():
     # If test is not found on report, should return failed grade
     assert evaluations[2]['grade'] == evaluation.FAILED_GRADE
     assert evaluations[2]['description'] == requirements[2]['description']
+    # If test xfailed, should return passed grade
+    assert evaluations[3]['grade'] == evaluation.PASSED_GRADE
+    assert evaluations[3]['description'] == requirements[3]['description']
 
 
 def test_generate_result_with_report_file_not_found():


### PR DESCRIPTION
No pytest, é possível marcar testes como `xfail`: espera-se que falhe.
Existe um recurso alternativo, `pytest.raises` que confirma que a implementação lança exceções nas condições esperadas. Mas `xfail` é o recomendado pro caso de implementações incompletas ou incorretas.

O novo projeto [Job Insights](https://github.com/betrybe/sd-0x-project-job-insights-rubric) é o primeiro projeto em python que pede pras pessoas estudantes escreverem testes originais e oferece implementações imperfeitas que _devem_ falhar -- espera-se que o teste da estudante pegue as falhas.

Para esse novo projeto (e pra futuros projetos), nosso evaluator precisa considerar `xfailed` como uma saída aceitável pros testes.