### PR TITLE
fix: ajusta pasta .venv e força DB_HOST como localhost

### DIFF
--- a/evaluate.sh
+++ b/evaluate.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+export DB_HOST=localhost
+
 python3 -m pip install virtualenv wheel --no-cache-dir
 
 # Install deps and run pytest over the student source
-python3 -m venv "~/$INPUT_PR_AUTHOR_USERNAME-project" --system-site-packages
-source "~/$INPUT_PR_AUTHOR_USERNAME-project/bin/activate"
+python3 -m venv ".venv/$INPUT_PR_AUTHOR_USERNAME-project" --system-site-packages
+source ".venv/$INPUT_PR_AUTHOR_USERNAME-project/bin/activate"
 if test -f "dev-requirements.txt" ; then
   python3 -m pip install -r dev-requirements.txt --no-cache-dir
 else
@@ -12,8 +14,8 @@ else
 fi
 python3 -m pytest --json=/tmp/report.json
 
-python3 -m venv "~/$INPUT_PR_AUTHOR_USERNAME-evaluator" --system-site-packages
-source "~/$INPUT_PR_AUTHOR_USERNAME-evaluator/bin/activate"
+python3 -m venv ".venv/$INPUT_PR_AUTHOR_USERNAME-evaluator" --system-site-packages
+source ".venv/$INPUT_PR_AUTHOR_USERNAME-evaluator/bin/activate"
 python3 -m pip install -r "$EVALUATOR_REQUIREMENTS"
 python3 "$EVALUATOR_SRC/evaluation.py" /tmp/report.json .trybe/requirements.json > /tmp/evaluation_result.json
 


### PR DESCRIPTION
Os projetos enviam o `DB_HOST` como `mondodb` pois antes era usado docker no avaliador, neste PR eu forço esta envvar ser localhost, evitando erro de conexão pois o alias `mongodb` dava erro