### PR TITLE
Ajusta action para que a versão do Python possa ser um input externo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ inputs.python_version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   py_job:
     name: Python CI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ jobs:
 
   Pull Request author username.
 
+- `python_version`
+
+  **Optional**
+
+  Evaluator's Python version
+
 ### Outputs
 
 - `result`

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,20 @@
-name: 'Pytest Evaluator'
-description: 'Run Pytest on project and return the results formatted'
+name: "Pytest Evaluator"
+description: "Run Pytest on project and return the results formatted"
 inputs:
   pr_author_username:
-    description: 'Pull Request author username'
+    description: "Pull Request author username"
     required: true
+  python_version:
+    default: "3.8"
+    description: "Python version"
+    required: false
 outputs:
   result:
-    description: 'Evaluation JSON results in base64 format.'
+    description: "Evaluation JSON results in base64 format."
     value: ${{ steps.run_pytest.outputs.result }}
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - id: run_pytest
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,20 +1,20 @@
-name: "Pytest Evaluator"
-description: "Run Pytest on project and return the results formatted"
+name: 'Pytest Evaluator'
+description: 'Run Pytest on project and return the results formatted'
 inputs:
   pr_author_username:
-    description: "Pull Request author username"
+    description: 'Pull Request author username'
     required: true
   python_version:
-    default: "3.8"
-    description: "Python version"
+    default: '3.8'
+    description: 'Python version'
     required: false
 outputs:
   result:
-    description: "Evaluation JSON results in base64 format."
+    description: 'Evaluation JSON results in base64 format.'
     value: ${{ steps.run_pytest.outputs.result }}
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - id: run_pytest
       shell: bash


### PR DESCRIPTION
Fixes #14 

Hoje o avaliador está travado na versão 3.8 do Python.
A 3.10 já está disponível, com features novas de peso, e a 3.11 já está para sair.

Modificar a versão do Python em todos os projetos de uma vez pode levar a bugs inesperados e a problemas de compatibilidade, portanto a solução proposta aqui foi ter uma input opcional para a action, onde a versão do Python pode ser especificada pelo projeto que usa a action, mantendo como padrão a 3.8.  
Com isso os problemas de compatibilidade com os projetos atuais são inexistentes, e podemos fazer alterações e testes pontuais em projetos específicos.