### PR TITLE
fix: atualiza set-output para utilizar variavel de ambiente

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pytest Evaluator Action
 
-This action run Pytest over project and build a evaluation `.json` as result
+Essa action executa o avaliador Pytest em projetos e exercícios da Trybe.
 
-### Install dependencies
+### Instalação de dependências
 
 ```sh
 make install
@@ -10,7 +10,7 @@ make install
 python3 -m pip install -r requirements.txt
 ```
 
-### Run tests
+### Testes
 
 ```sh
 make test
@@ -20,93 +20,55 @@ python3 -m pytest
 
 ## Evaluator Action
 
-To call the evaluator action you must create `.github/workflows/main.yml` in the project repo with the release version.
+Para executar a action é preciso criar ou editar o arquivo `.github/workflows/main.yml` no repositório do exercício/projeto, e incluir as etapas `Fetch PyTest evaluator`, `Set Python Version` e `Run PyTest evaluation`, como exemplificado abaixo:
 
 ```yml
 on:
-  workflow_dispatch:
-    inputs:
-      dispatch_token:
-        description: 'Token that authorize the dispatch'
-        required: true
-      head_sha:
-        description: 'Head commit SHA that dispatched the workflow'
-        required: true
-      pr_author_username:
-        description: 'Pull Request author username'
-        required: true
-      pr_number:
-        description: 'Pull Request number that dispatched the workflow'
-        required: true
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
-  evaluator_job:
-    name: Evaluator Job
-    runs-on: ubuntu-18.04
+  evaluator:
+    timeout-minutes: 20
+    runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v3
+      ...
 
-      - uses: actions/setup-python@v4
+      - name: Fetch PyTest evaluator
+        uses: actions/checkout@v3
         with:
-          python-version: '3.x'
+          repository: betrybe/pytest-evaluator-action
+          ref: v6.0
+          token: ${{ secrets.GIT_HUB_PAT }}
+          path: .github/actions/pytest-evaluator
 
-      - name: Pytest Evaluator Step
-        uses: betrybe/pytest-evaluator-action@v3
+      - name: Set Python Version
+        uses: actions/setup-python@v4
         with:
-          pr_author_username: ${{ github.event.inputs.pr_author_username }}
-        id: pytest_evaluator
+          python-version: "3.10.6"
 
-      - name: Store evaluation step
-        uses: betrybe/store-evaluation-action@v2
+      - name: Run PyTest evaluation
+        id: evaluator
+        uses: ./.github/actions/pytest-evaluator
         with:
-          evaluation-data: ${{ steps.pytest_evaluator.outputs.result }}
-          environment: staging
-          pr-number: ${{ github.event.inputs.pr_number }}
+          pr_author_username: ${{ github.event.pull_request.user.login }}
 
+      - name: Run Store evaluation
+        uses: ./.github/actions/store-evaluation
+        with:
+          evaluation-data: ${{ steps.evaluator.outputs.result }}
+          environment: production
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Inputs
 
-- `pr_author_username`
-
-  **Required**
-
-  Pull Request author username.
+- `pr_author_username` (**obrigatório**)
+  
+  O GitHub username do autor do Pull Request.
 
 ### Outputs
 
 - `result`
-
-  Evaluation result JSON in base64 format.
-
-## Trybe requirements and expected results
-
-In your project repository must create a file called `requirements.json` inside `.trybe` folder.
-
-This file should have the following structure:
-
-```json
-{
-  "requirements": [
-    {
-      "identifier": "test_desafio1",
-      "description": "requirement #1",
-      "bonus": false
-    },
-    {
-      "identifier": "test_desafio2",
-      "description": "requirement #2",
-      "bonus": true
-    },
-    {
-      "identifier": "test_desafio3",
-      "description": "requirement #3",
-      "bonus": false
-    }
-  ]
-}
-```
-
-where:
-- the `"requirement #1"`, `"requirement #2"` and `"requirement #3"` are the **requirements description**
-- the `identifier` must be **exactly the same** as the **test function name** (e.g. `test_function_a`)
+  
+  O resultado da avaliação em JSON codificado em base64.

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -25,6 +25,4 @@ if [ $? != 0 ]; then
 fi
 
 echo `cat /tmp/evaluation_result.json | base64 -w 0`
-# echo ::set-output name=result::`cat /tmp/evaluation_result.json | base64 -w 0`
-
-echo name=result >> $GITHUB_OUTPUT `cat /tmp/evaluation_result.json | base64 -w 0`
+echo "result=`cat /tmp/evaluation_result.json | base64 -w 0`" >> $GITHUB_OUTPUT

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -25,4 +25,6 @@ if [ $? != 0 ]; then
 fi
 
 echo `cat /tmp/evaluation_result.json | base64 -w 0`
-echo ::set-output name=result::`cat /tmp/evaluation_result.json | base64 -w 0`
+# echo ::set-output name=result::`cat /tmp/evaluation_result.json | base64 -w 0`
+
+echo name=result >> $GITHUB_OUTPUT `cat /tmp/evaluation_result.json | base64 -w 0`


### PR DESCRIPTION
## Tarefa
- [LEARN-7591](https://trybe.atlassian.net/jira/software/c/projects/LEARN/boards/130?modal=detail&selectedIssue=LEARN-7591)

## Contexto
[A partir do dia 31 de maio de 2023, o set-output será deprecado](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

Será preciso modificar o arquivo `evaluate.sh` para usar a variável de ambiente **$GITHUB_OUTPUT**.

[LEARN-7591]: https://trybe.atlassian.net/browse/LEARN-7591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ